### PR TITLE
Don't apply abspath on http and s3 path strings

### DIFF
--- a/src/Setup/utilsSetup.jl
+++ b/src/Setup/utilsSetup.jl
@@ -14,6 +14,9 @@ Converts a relative data path to an absolute path based on the experiment direct
 An absolute data path.
 """
 function getAbsDataPath(info, data_path)
+    if startswith(data_path, "http") || startswith(data_path, "s3://")
+        return data_path
+    end
     if !isabspath(data_path)
         d_data_path = getSindbadDataDepot(local_data_depot=data_path)
         if data_path == d_data_path


### PR DESCRIPTION
This allows to open remote zarr data as forcing or observation data. 