### PR TITLE
Stop deploydocs from pushing PR preview builds to gh-pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,9 +23,9 @@ makedocs(; sitename="Sindbad",
     build="build",
     )
 
-DocumenterVitepress.deploydocs(; 
+DocumenterVitepress.deploydocs(;
     repo = "github.com/LandEcosystems/Sindbad.jl.git", # this must be the full URL!
     branch = "gh-pages",
     devbranch = "main",
-    push_preview = true
+    push_preview = false # don't push PR preview builds to gh-pages; still builds (and deploys) on push to main/tags
 )


### PR DESCRIPTION
## Summary
- Sets `push_preview = false` in `docs/make.jl`'s `deploydocs` call, so pull_request-triggered Documenter builds no longer push preview docs to the `gh-pages` branch (under `previews/PR<n>/`).
- Push-to-`main` and tag-triggered deploys (`dev`/`stable`/`vX.Y`) are unaffected -- this only stops the PR-preview side effect.

## Test plan
- [x] Confirmed via `docs/make.jl` review that `push_preview` is the documented Documenter/DocumenterVitepress flag controlling PR-preview deployment specifically.