### PR TITLE
Reduce per-push CI cost, add on-demand full-matrix/simulation checks …

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,16 +10,21 @@
 
 Every PR runs a fast, ubuntu-only check automatically on every push (required to merge).
 The checks below are on-demand -- not required to merge, but expected before merging anything
-that could plausibly break on another OS or affect the example setups. Trigger them either way:
+that could plausibly break on another OS, affect the example setups, or break the docs build.
+Trigger them either way:
 
 - Actions tab -> pick the workflow -> Run workflow -> select this branch, or
-- comment on this PR: `/run-full-matrix` (Sindbad.jl + SindbadTEM.jl across all OSes) or
-  `/run-simulations` (Test Simulations)
+- comment on this PR: `/run-full-matrix` (Sindbad.jl + SindbadTEM.jl across all OSes),
+  `/run-simulations` (Test Simulations), or `/run-docs` (docs build)
 
-Either way, the result is posted back to this PR automatically as a comment when it finishes.
+`/run-full-matrix` and `/run-simulations` post their result back to this PR automatically as a
+comment when they finish. `/run-docs` reports via its own `documenter/deploy` status check
+instead (same as it always has).
 
 - [ ] If this PR could behave differently across operating systems: ran `/run-full-matrix` (or
       the Sindbad.jl/SindbadTEM.jl workflows manually) against this branch.
 - [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
       setups' forward/optimization runs: ran `/run-simulations` (or the Test Simulations
       workflow manually) against this branch.
+- [ ] If this PR changes `docs/` or anything documented via docstrings: ran `/run-docs` (or the
+      Documenter workflow manually) against this branch.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,15 +14,15 @@ that could plausibly break on another OS, affect the example setups, or break th
 Trigger them either way:
 
 - Actions tab -> pick the workflow -> Run workflow -> select this branch, or
-- comment on this PR: `/run-checks` (Sindbad.jl + SindbadTEM.jl across all OSes, plus the docs
+- comment on this PR: `/check-pr` (Sindbad.jl + SindbadTEM.jl across all OSes, plus the docs
   build) or `/run-simulations` (Test Simulations)
 
-`/run-checks` posts a PR comment for the Sindbad.jl/SindbadTEM.jl matrix result, and reports the
+`/check-pr` posts a PR comment for the Sindbad.jl/SindbadTEM.jl matrix result, and reports the
 docs build via its own `documenter/deploy` status check (same as it always has). `/run-simulations`
 posts its result back to this PR automatically as a comment.
 
 - [ ] If this PR could behave differently across operating systems, or changes `docs/` or
-      anything documented via docstrings: ran `/run-checks` (or the Sindbad.jl/SindbadTEM.jl/
+      anything documented via docstrings: ran `/check-pr` (or the Sindbad.jl/SindbadTEM.jl/
       Documenter workflows manually) against this branch.
 - [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
       setups' forward/optimization runs: ran `/run-simulations` (or the Test Simulations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,18 @@
 
 ## Checklist
 
+Every PR runs a fast, ubuntu-only check automatically on every push (required to merge).
+The checks below are on-demand -- not required to merge, but expected before merging anything
+that could plausibly break on another OS or affect the example setups. Trigger them either way:
+
+- Actions tab -> pick the workflow -> Run workflow -> select this branch, or
+- comment on this PR: `/run-full-matrix` (Sindbad.jl + SindbadTEM.jl across all OSes) or
+  `/run-simulations` (Test Simulations)
+
+Either way, the result is posted back to this PR automatically as a comment when it finishes.
+
+- [ ] If this PR could behave differently across operating systems: ran `/run-full-matrix` (or
+      the Sindbad.jl/SindbadTEM.jl workflows manually) against this branch.
 - [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
-      setups' forward/optimization runs: ran the manually-triggered "Test Simulations" workflow
-      (Actions tab -> Test Simulations -> Run workflow) against this branch, and pasted the
-      resulting report table below (or linked the workflow run).
-
-<details>
-<summary>Test Simulations</summary>
-
-<!-- Paste the report table here, or a link to the workflow run. -->
-
-</details>
+      setups' forward/optimization runs: ran `/run-simulations` (or the Test Simulations
+      workflow manually) against this branch.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,24 +6,13 @@
 
 <!-- How did you verify this works? -->
 
-## Checklist
+## On-demand checks
 
 Every PR runs a fast, ubuntu-only check automatically on every push (required to merge).
-The checks below are on-demand -- not required to merge, but expected before merging anything
-that could plausibly break on another OS, affect the example setups, or break the docs build.
-Trigger them either way:
+For full OS coverage, the example setups, or the docs build, trigger the on-demand checks
+before merging -- results post back to this PR as comments automatically:
 
-- Actions tab -> pick the workflow -> Run workflow -> select this branch, or
-- comment on this PR: `/check-pr` (Sindbad.jl + SindbadTEM.jl across all OSes, plus the docs
-  build) or `/run-simulations` (Test Simulations)
+- `/check-pr` -- Sindbad.jl + SindbadTEM.jl across all OSes, plus the docs build
+- `/run-simulations` -- Test Simulations
 
-`/check-pr` posts a PR comment for the Sindbad.jl/SindbadTEM.jl matrix result, and reports the
-docs build via its own `documenter/deploy` status check (same as it always has). `/run-simulations`
-posts its result back to this PR automatically as a comment.
-
-- [ ] If this PR could behave differently across operating systems, or changes `docs/` or
-      anything documented via docstrings: ran `/check-pr` (or the Sindbad.jl/SindbadTEM.jl/
-      Documenter workflows manually) against this branch.
-- [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
-      setups' forward/optimization runs: ran `/run-simulations` (or the Test Simulations
-      workflow manually) against this branch.
+(or Actions tab -> pick the workflow -> Run workflow -> select this branch)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,17 +14,16 @@ that could plausibly break on another OS, affect the example setups, or break th
 Trigger them either way:
 
 - Actions tab -> pick the workflow -> Run workflow -> select this branch, or
-- comment on this PR: `/run-full-matrix` (Sindbad.jl + SindbadTEM.jl across all OSes),
-  `/run-simulations` (Test Simulations), or `/run-docs` (docs build)
+- comment on this PR: `/run-checks` (Sindbad.jl + SindbadTEM.jl across all OSes, plus the docs
+  build) or `/run-simulations` (Test Simulations)
 
-`/run-full-matrix` and `/run-simulations` post their result back to this PR automatically as a
-comment when they finish. `/run-docs` reports via its own `documenter/deploy` status check
-instead (same as it always has).
+`/run-checks` posts a PR comment for the Sindbad.jl/SindbadTEM.jl matrix result, and reports the
+docs build via its own `documenter/deploy` status check (same as it always has). `/run-simulations`
+posts its result back to this PR automatically as a comment.
 
-- [ ] If this PR could behave differently across operating systems: ran `/run-full-matrix` (or
-      the Sindbad.jl/SindbadTEM.jl workflows manually) against this branch.
+- [ ] If this PR could behave differently across operating systems, or changes `docs/` or
+      anything documented via docstrings: ran `/run-checks` (or the Sindbad.jl/SindbadTEM.jl/
+      Documenter workflows manually) against this branch.
 - [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
       setups' forward/optimization runs: ran `/run-simulations` (or the Test Simulations
       workflow manually) against this branch.
-- [ ] If this PR changes `docs/` or anything documented via docstrings: ran `/run-docs` (or the
-      Documenter workflow manually) against this branch.

--- a/.github/scripts/upsert_pr_comment.sh
+++ b/.github/scripts/upsert_pr_comment.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Posts body_file as a comment on PR pr_number, or edits its own previous comment in place if
+# one already exists (identified by an HTML marker comment, invisible when rendered) -- so
+# repeated on-demand CI runs update a single comment instead of piling up new ones each time.
+#
+# Usage: upsert_pr_comment.sh <pr_number> <marker> <body_file>
+# Requires: GH_TOKEN (or gh auth), GITHUB_REPOSITORY set (both present by default in Actions).
+set -euo pipefail
+
+pr_number="$1"
+marker="$2"
+body_file="$3"
+marker_tag="<!-- ci-comment-marker: ${marker} -->"
+
+existing_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" --paginate \
+  --jq ".[] | select(.body | startswith(\"${marker_tag}\")) | .id" | head -n1)
+
+if [ -n "$existing_id" ]; then
+  gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -X PATCH -F body=@"${body_file}" >/dev/null
+  echo "Updated existing comment ${existing_id} on PR #${pr_number}"
+else
+  gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" -X POST -F body=@"${body_file}" >/dev/null
+  echo "Created new comment on PR #${pr_number}"
+fi

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
     tags: ['*']
-  pull_request:
   workflow_dispatch:
 
 # Add permissions for GitHub Actions to push to gh-pages

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -47,7 +47,38 @@ jobs:
         id: julia-cache-save
         if: cancelled() || failure()
         uses: actions/cache/save@v6
-        with: 
+        with:
           path: |
             ${{ steps.julia-cache.outputs.cache-paths }}
           key: ${{ steps.julia-cache.outputs.cache-key }}
+
+  # Posts/updates a sticky comment on the PR whose branch this was dispatched against, so the
+  # docs build result shows up alongside the /check-pr matrix report instead of only as the
+  # separate documenter/deploy status check. Only meaningful for workflow_dispatch -- push
+  # (post-merge/tag) has no PR to comment on.
+  report:
+    needs: build
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Post result to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.build.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
+            exit 0
+          fi
+          {
+            echo "<!-- ci-comment-marker: docs-build -->"
+            echo "### Docs build: $RESULT"
+            echo ""
+            echo "[View run]($RUN_URL)"
+          } > /tmp/comment_body.md
+          .github/scripts/upsert_pr_comment.sh "$pr_number" "docs-build" /tmp/comment_body.md

--- a/.github/workflows/Sindbad.yml
+++ b/.github/workflows/Sindbad.yml
@@ -124,11 +124,9 @@ jobs:
             echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
             exit 0
           fi
-          icon="✅"
-          if [ "$RESULT" != "success" ]; then icon="❌"; fi
           {
             echo "<!-- ci-comment-marker: sindbad-full-matrix -->"
-            echo "### $icon Sindbad.jl full OS matrix: $RESULT"
+            echo "### Sindbad.jl full OS matrix: $RESULT"
             echo ""
             echo "[View run]($RUN_URL) (Julia lts/1 x ubuntu/macOS/windows)"
           } > /tmp/comment_body.md

--- a/.github/workflows/Sindbad.yml
+++ b/.github/workflows/Sindbad.yml
@@ -11,14 +11,58 @@ on:
       - '*'
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+  # Runs on every push to a PR -- ubuntu only, both Julia versions. Kept fast/cheap so it's
+  # reasonable to require before merge. For full OS coverage, use the "full-matrix" job below
+  # (Actions tab -> Run workflow, or comment `/run-full-matrix` on the PR -- see ci-commands.yml).
+  quick:
+    if: github.event_name == 'pull_request'
+    name: "Sindbad: Julia ${{ matrix.version }} - ${{ matrix.os }} - quick"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'lts'
+          - '1'
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - name: Develop and test Sindbad
+        shell: julia --project=. {0}
+        run: |
+          using Pkg
+          # CI should not rely on developer-local Manifests that point to /Users/... paths.
+          rm("Manifest.toml"; force=true)
+          Pkg.instantiate()  # Install all dependencies
+          Pkg.test("Sindbad"; coverage=true)
+      - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: src
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+
+  # Full OS x Julia-version matrix. Runs automatically after merge to main / on tag push, and
+  # on demand (workflow_dispatch) against any branch -- including an open PR's branch, so you
+  # can validate the full matrix before merging without paying for it on every commit.
+  full-matrix:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: "Sindbad: Julia ${{ matrix.version }} - ${{ matrix.os }} - full"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     continue-on-error: ${{ matrix.allow_failure }}
@@ -57,3 +101,35 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+
+  # Posts/updates a sticky comment on the PR whose branch this was dispatched against, so the
+  # result of an on-demand full-matrix run shows up in the PR without manual copy/paste.
+  # Only meaningful for workflow_dispatch -- push (post-merge/tag) has no PR to comment on.
+  report:
+    needs: full-matrix
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Post result to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.full-matrix.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
+            exit 0
+          fi
+          icon="✅"
+          if [ "$RESULT" != "success" ]; then icon="❌"; fi
+          {
+            echo "<!-- ci-comment-marker: sindbad-full-matrix -->"
+            echo "### $icon Sindbad.jl full OS matrix: $RESULT"
+            echo ""
+            echo "[View run]($RUN_URL) (Julia lts/1 x ubuntu/macOS/windows)"
+          } > /tmp/comment_body.md
+          .github/scripts/upsert_pr_comment.sh "$pr_number" "sindbad-full-matrix" /tmp/comment_body.md

--- a/.github/workflows/SindbadTEM.yml
+++ b/.github/workflows/SindbadTEM.yml
@@ -126,11 +126,9 @@ jobs:
             echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
             exit 0
           fi
-          icon="✅"
-          if [ "$RESULT" != "success" ]; then icon="❌"; fi
           {
             echo "<!-- ci-comment-marker: sindbadtem-full-matrix -->"
-            echo "### $icon SindbadTEM.jl full OS matrix: $RESULT"
+            echo "### SindbadTEM.jl full OS matrix: $RESULT"
             echo ""
             echo "[View run]($RUN_URL) (Julia lts/1 x ubuntu/macOS/windows)"
           } > /tmp/comment_body.md

--- a/.github/workflows/SindbadTEM.yml
+++ b/.github/workflows/SindbadTEM.yml
@@ -11,14 +11,59 @@ on:
       - '*'
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+  # Runs on every push to a PR -- ubuntu only, both Julia versions. Kept fast/cheap so it's
+  # reasonable to require before merge. For full OS coverage, use the "full-matrix" job below
+  # (Actions tab -> Run workflow, or comment `/run-full-matrix` on the PR -- see ci-commands.yml).
+  quick:
+    if: github.event_name == 'pull_request'
+    name: "SindbadTEM: Julia ${{ matrix.version }} - ${{ matrix.os }} - quick"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'lts'
+          - '1'
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - name: Develop and test SindbadTEM
+        shell: julia --project=SindbadTEM {0}
+        run: |
+          using Pkg
+          # CI should not rely on developer-local Manifests that point to /Users/... paths.
+          # (When running with `--project=SindbadTEM`, the manifest lives in `SindbadTEM/Manifest.toml`.)
+          rm(joinpath("SindbadTEM","Manifest.toml"); force=true)
+          Pkg.instantiate()
+          Pkg.test("SindbadTEM"; coverage=true)
+      - uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: SindbadTEM/src
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info
+
+  # Full OS x Julia-version matrix. Runs automatically after merge to main / on tag push, and
+  # on demand (workflow_dispatch) against any branch -- including an open PR's branch, so you
+  # can validate the full matrix before merging without paying for it on every commit.
+  full-matrix:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: "SindbadTEM: Julia ${{ matrix.version }} - ${{ matrix.os }} - full"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     continue-on-error: ${{ matrix.allow_failure }}
@@ -58,3 +103,35 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+
+  # Posts/updates a sticky comment on the PR whose branch this was dispatched against, so the
+  # result of an on-demand full-matrix run shows up in the PR without manual copy/paste.
+  # Only meaningful for workflow_dispatch -- push (post-merge/tag) has no PR to comment on.
+  report:
+    needs: full-matrix
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Post result to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.full-matrix.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
+            exit 0
+          fi
+          icon="✅"
+          if [ "$RESULT" != "success" ]; then icon="❌"; fi
+          {
+            echo "<!-- ci-comment-marker: sindbadtem-full-matrix -->"
+            echo "### $icon SindbadTEM.jl full OS matrix: $RESULT"
+            echo ""
+            echo "[View run]($RUN_URL) (Julia lts/1 x ubuntu/macOS/windows)"
+          } > /tmp/comment_body.md
+          .github/scripts/upsert_pr_comment.sh "$pr_number" "sindbadtem-full-matrix" /tmp/comment_body.md

--- a/.github/workflows/TestSimulations.yml
+++ b/.github/workflows/TestSimulations.yml
@@ -51,6 +51,8 @@ jobs:
     needs: simulate
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -69,3 +71,23 @@ jobs:
           include(joinpath(ENV["GITHUB_WORKSPACE"], "examples", "scripts", "combine_simulation_reports.jl"))
         env:
           SIMULATION_REPORT_DIR: reports
+      # Runs even if the step above failed (some/all simulations errored) -- post whatever
+      # report was produced to the PR either way, rather than only reporting successes.
+      - name: Post result to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for branch ${{ github.ref_name }}; skipping comment."
+            exit 0
+          fi
+          {
+            echo "<!-- ci-comment-marker: test-simulations -->"
+            echo "[View run]($RUN_URL)"
+            echo ""
+            cat output_simulation_report_combined.md
+          } > /tmp/comment_body.md
+          .github/scripts/upsert_pr_comment.sh "$pr_number" "test-simulations" /tmp/comment_body.md

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -1,0 +1,61 @@
+name: CI commands
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  # Lets maintainers trigger the on-demand CI workflows by commenting on a PR, instead of
+  # going to the Actions tab (both work -- see Sindbad.yml/SindbadTEM.yml/TestSimulations.yml).
+  # Gated to comments on PRs, from users with write access, matching a known command -- this
+  # only dispatches other workflows against the PR's branch, the same trust level as a
+  # maintainer manually clicking "Run workflow"; it never checks out or runs PR code itself.
+  dispatch:
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      (contains(github.event.comment.body, '/run-full-matrix') || contains(github.event.comment.body, '/run-simulations'))
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Resolve PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch=$(gh pr view "${{ github.event.issue.number }}" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=rocket >/dev/null
+
+      - name: Dispatch full matrix
+        if: contains(github.event.comment.body, '/run-full-matrix')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run Sindbad.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
+          gh workflow run SindbadTEM.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
+
+      - name: Dispatch test simulations
+        if: contains(github.event.comment.body, '/run-simulations')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run TestSimulations.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
+
+      - name: Confirm
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" --repo "$GITHUB_REPOSITORY" --body \
+            "Triggered the requested workflow(s) on \`${{ steps.pr.outputs.branch }}\`. Check the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions) for progress -- results will be posted back here when done."

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -17,7 +17,7 @@ jobs:
     if: >
       github.event.issue.pull_request != null &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-      (contains(github.event.comment.body, '/run-checks') || contains(github.event.comment.body, '/run-simulations'))
+      (contains(github.event.comment.body, '/check-pr') || contains(github.event.comment.body, '/run-simulations'))
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -40,7 +40,7 @@ jobs:
             -f content=rocket >/dev/null
 
       - name: Dispatch full matrix + docs
-        if: contains(github.event.comment.body, '/run-checks')
+        if: contains(github.event.comment.body, '/check-pr')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -17,7 +17,7 @@ jobs:
     if: >
       github.event.issue.pull_request != null &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-      (contains(github.event.comment.body, '/run-full-matrix') || contains(github.event.comment.body, '/run-simulations') || contains(github.event.comment.body, '/run-docs'))
+      (contains(github.event.comment.body, '/run-checks') || contains(github.event.comment.body, '/run-simulations'))
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -39,13 +39,14 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=rocket >/dev/null
 
-      - name: Dispatch full matrix
-        if: contains(github.event.comment.body, '/run-full-matrix')
+      - name: Dispatch full matrix + docs
+        if: contains(github.event.comment.body, '/run-checks')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run Sindbad.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
           gh workflow run SindbadTEM.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
+          gh workflow run Documenter.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
 
       - name: Dispatch test simulations
         if: contains(github.event.comment.body, '/run-simulations')
@@ -53,13 +54,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run TestSimulations.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
-
-      - name: Dispatch docs build
-        if: contains(github.event.comment.body, '/run-docs')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run Documenter.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
 
       - name: Confirm
         env:

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -8,15 +8,16 @@ permissions:
 
 jobs:
   # Lets maintainers trigger the on-demand CI workflows by commenting on a PR, instead of
-  # going to the Actions tab (both work -- see Sindbad.yml/SindbadTEM.yml/TestSimulations.yml).
-  # Gated to comments on PRs, from users with write access, matching a known command -- this
-  # only dispatches other workflows against the PR's branch, the same trust level as a
-  # maintainer manually clicking "Run workflow"; it never checks out or runs PR code itself.
+  # going to the Actions tab (both work -- see Sindbad.yml/SindbadTEM.yml/TestSimulations.yml/
+  # Documenter.yml). Gated to comments on PRs, from users with write access, matching a known
+  # command -- this only dispatches other workflows against the PR's branch, the same trust
+  # level as a maintainer manually clicking "Run workflow"; it never checks out or runs PR code
+  # itself.
   dispatch:
     if: >
       github.event.issue.pull_request != null &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-      (contains(github.event.comment.body, '/run-full-matrix') || contains(github.event.comment.body, '/run-simulations'))
+      (contains(github.event.comment.body, '/run-full-matrix') || contains(github.event.comment.body, '/run-simulations') || contains(github.event.comment.body, '/run-docs'))
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -52,6 +53,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run TestSimulations.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
+
+      - name: Dispatch docs build
+        if: contains(github.event.comment.body, '/run-docs')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run Documenter.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.pr.outputs.branch }}"
 
       - name: Confirm
         env:

--- a/examples/scripts/combine_simulation_reports.jl
+++ b/examples/scripts/combine_simulation_reports.jl
@@ -77,8 +77,9 @@ if !isnothing(summary_path)
     open(summary_path, "a") do f
         println(f, report)
     end
-else
-    write("output_simulation_report_combined.md", report)
 end
+# Always written (in addition to GITHUB_STEP_SUMMARY when running in Actions) so a later
+# workflow step can pick this file up to post it as a PR comment.
+write("output_simulation_report_combined.md", report)
 
 any(row.ok != "true" for row in rows) && error("one or more example runs failed; see report above")


### PR DESCRIPTION
…with PR reporting

Sindbad.yml and SindbadTEM.yml now split into a "quick" job (ubuntu-only, Julia lts+1, runs on every PR push -- the previous 6-job full matrix on every commit was the actual pain point) and a "full-matrix" job (all three OSes, runs after merge/tag push same as before, or on demand via workflow_dispatch against any branch including an open PR's).

Both full-matrix jobs and TestSimulations.yml's combine job now post/update a sticky comment on the PR whose branch they were dispatched against (via the new .github/scripts/upsert_pr_comment.sh, matched by an HTML marker so re-runs update the same comment instead of piling up), so an on-demand run's result shows up automatically instead of the previous manual copy-paste-into-PR workflow.

Added ci-commands.yml: lets maintainers trigger full-matrix/simulations by commenting `/run-full-matrix` or `/run-simulations` on a PR, as an alternative to the Actions tab. Gated to comments on PRs from users with write access (author_association), and only ever dispatches the other workflows against the PR's branch -- it doesn't check out or run any PR code itself, same trust level as manually clicking "Run workflow".

combine_simulation_reports.jl now always writes its report to output_simulation_report_combined.md (previously only when GITHUB_STEP_SUMMARY was unset), so the new PR-comment step can read it.

Updated PULL_REQUEST_TEMPLATE.md to document both trigger methods and that only the quick check is required to merge -- the full-matrix and Test Simulations checks are on-demand by design, so hard-requiring them would re-block every new commit until manually re-triggered.

## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this works? -->

## Checklist

- [ ] If this PR changes `examples/`, `src/`, or anything else that could affect the example
      setups' forward/optimization runs: ran the manually-triggered "Test Simulations" workflow
      (Actions tab -> Test Simulations -> Run workflow) against this branch, and pasted the
      resulting report table below (or linked the workflow run).

<details>
<summary>Test Simulations</summary>

<!-- Paste the report table here, or a link to the workflow run. -->

</details>
