### PR TITLE
Sk/n timestep

### DIFF
--- a/SindbadTEM/Project.toml
+++ b/SindbadTEM/Project.toml
@@ -5,7 +5,7 @@ authors = ["SINDBAD Contributors <sindbad@bgc-jena.mpg.de>"]
 description = "Core terrestrial ecosystem model types and utilities for the SINDBAD framework"
 readme = "README.md"
 repository = "https://github.com/LandEcosystems/Sindbad.jl.git"
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/SindbadTEM/src/Utils.jl
+++ b/SindbadTEM/src/Utils.jl
@@ -14,6 +14,7 @@ module Utils
     export getSindbadModels
     export getTypedModel
     export getUnitConversionForParameter
+    export parseTemporalResolution
     export modelParameter
     export modelParameters
 
@@ -406,6 +407,38 @@ end
 
 
 """
+    parseTemporalResolution(resolution)
+
+Parses a temporal resolution string into an integer count and a base unit string.
+
+Accepts either a bare unit (e.g. "day", "hour") or an n-unit string of the form
+"<positive integer>-<unit>" (e.g. "6-hour", "2-day", "3-month"). A bare unit is
+equivalent to "1-<unit>".
+
+# Arguments:
+- `resolution`: a temporal resolution string, e.g. "day", "6-hour", "3-month"
+
+# Returns:
+- `(n::Int, unit::String)`: the multiplier count and the base unit string.
+"""
+function parseTemporalResolution(resolution)
+    parts = split(String(resolution), "-")
+    if length(parts) == 1
+        return 1, String(parts[1])
+    elseif length(parts) == 2
+        n = tryparse(Int, parts[1])
+        if isnothing(n)
+            error("invalid temporal resolution \"$(resolution)\": count \"$(parts[1])\" is not an integer. Expected format \"<integer>-<unit>\", e.g. \"6-hour\".")
+        elseif n <= 0
+            error("invalid temporal resolution \"$(resolution)\": count must be a positive integer, got $(n).")
+        end
+        return n, String(parts[2])
+    else
+        error("invalid temporal resolution \"$(resolution)\": expected a bare unit (e.g. \"day\") or \"<integer>-<unit>\" (e.g. \"6-hour\"), got $(length(parts)) dash-separated parts.")
+    end
+end
+
+"""
     getUnitConversionForParameter(p_timescale, model_timestep)
 
 helper/wrapper function to get unit conversion factors for model parameters that are timescale dependent
@@ -415,50 +448,63 @@ helper/wrapper function to get unit conversion factors for model parameters that
 - `model_timestep`: time step of the model run
 """
 function getUnitConversionForParameter(p_timescale, model_timestep)
+    p_n, p_unit = parseTemporalResolution(p_timescale)
+    m_n, m_unit = parseTemporalResolution(model_timestep)
+    if p_n != 1 || m_n != 1
+        base_conversion = getUnitConversionForParameter(p_unit, m_unit)
+        # an empty p_unit means the parameter has no declared timescale (not time-dependent),
+        # so it must stay a no-op regardless of any n-unit multiplier on either side
+        return isempty(p_unit) ? base_conversion : base_conversion * m_n / p_n
+    end
+
     conversion = 1
     time_multiplier = 1
     # time multiplier compared to daily time steps
-    if model_timestep == "second"
+    if m_unit == "second"
         time_multiplier = 1/(60* 60 * 24)
-    elseif model_timestep == "minute"
+    elseif m_unit == "minute"
         time_multiplier = 1/(60 * 24)
-    elseif model_timestep == "halfhour"
+    elseif m_unit == "halfhour"
         time_multiplier = 1/48
-    elseif model_timestep == "hour"
+    elseif m_unit == "hour"
         time_multiplier = 1/24
-    elseif model_timestep == "day"
+    elseif m_unit == "day"
         time_multiplier = 1
-    elseif model_timestep == "week"
+    elseif m_unit == "week"
         time_multiplier = 7
-    elseif model_timestep == "month"
+    elseif m_unit == "month"
         time_multiplier = 30
-    elseif model_timestep == "year"
+    elseif m_unit == "year"
         time_multiplier = 365
-    elseif model_timestep == "decade"
+    elseif m_unit == "decade"
         time_multiplier = 365 * 10
     else
         error("running model at $(model_timestep) is not supported")
     end
 
     # modelling at other time steps
-    if p_timescale == "second"
+    if p_unit == "second"
         conversion = 60 * 60 * 24 * time_multiplier
-    elseif p_timescale == "minute"
+    elseif p_unit == "minute"
         conversion = 60 * 24 * time_multiplier
-    elseif p_timescale == "halfhour"
+    elseif p_unit == "halfhour"
         conversion = 48 * time_multiplier
-    elseif p_timescale == "hour"
+    elseif p_unit == "hour"
         conversion = 24 * time_multiplier
-    elseif p_timescale == "day"
+    elseif p_unit == "day"
         conversion = 1 * time_multiplier
-    elseif p_timescale == "week"
+    elseif p_unit == "week"
         conversion = 1/7 * time_multiplier
-    elseif p_timescale == "month"
+    elseif p_unit == "month"
         conversion = 1/30 * time_multiplier
-    elseif p_timescale == "year"
+    elseif p_unit == "year"
         conversion = 1/365 * time_multiplier
-    elseif p_timescale == "decade"
+    elseif p_unit == "decade"
         conversion = 1/(365 * 10) * time_multiplier
+    elseif isempty(p_unit)
+        conversion = 1
+    else
+        error("parameter timescale \"$(p_timescale)\" is not supported")
     end
     return conversion
 end

--- a/SindbadTEM/test/runtests.jl
+++ b/SindbadTEM/test/runtests.jl
@@ -18,6 +18,7 @@ include(joinpath("test_data", "helpers.jl"))
 # provides tmp_forcing, land, reference_approaches, tmp_helpers
 
 include("testDataCoverage.jl")
+include("testUnitConversion.jl")
 # checkApproaches.jl (every approach's define/precompute/compute -- update is opt-in, off by
 # default -- run against the real process sequence) deliberately isn't included here: it's pure
 # Julia logic with no OS-specific behavior, so running it across Pkg.test's full 3-OS x

--- a/SindbadTEM/test/testUnitConversion.jl
+++ b/SindbadTEM/test/testUnitConversion.jl
@@ -1,0 +1,47 @@
+@testset "parseTemporalResolution" begin
+    @test parseTemporalResolution("day") == (1, "day")
+    @test parseTemporalResolution("hour") == (1, "hour")
+    @test parseTemporalResolution("") == (1, "")
+    @test parseTemporalResolution("6-hour") == (6, "hour")
+    @test parseTemporalResolution("1-day") == (1, "day")
+    @test parseTemporalResolution("2-day") == (2, "day")
+    @test parseTemporalResolution("3-month") == (3, "month")
+
+    @test_throws ErrorException parseTemporalResolution("0-hour")
+    @test_throws ErrorException parseTemporalResolution("-1-hour")
+    @test_throws ErrorException parseTemporalResolution("abc-hour")
+    @test_throws ErrorException parseTemporalResolution("6.5-hour")
+    @test_throws ErrorException parseTemporalResolution("6-6-hour")
+end
+
+@testset "getUnitConversionForParameter" begin
+    # regression: bare units unchanged
+    @test getUnitConversionForParameter("day", "hour") == 1/24
+    @test getUnitConversionForParameter("hour", "day") == 24
+    @test getUnitConversionForParameter("day", "day") == 1
+    @test getUnitConversionForParameter("month", "day") == 1/30
+    @test getUnitConversionForParameter("year", "second") == 1/365 * 1/(60*60*24)
+
+    # empty p_timescale (the common "not time-dependent" default) stays a no-op
+    @test getUnitConversionForParameter("", "day") == 1
+    @test getUnitConversionForParameter("", "6-hour") == 1
+
+    # n-unit on model_timestep side
+    @test getUnitConversionForParameter("day", "6-hour") == getUnitConversionForParameter("day", "hour") * 6
+    @test getUnitConversionForParameter("day", "1-hour") == getUnitConversionForParameter("day", "hour")
+
+    # n-unit on p_timescale side
+    @test getUnitConversionForParameter("6-hour", "day") == getUnitConversionForParameter("hour", "day") / 6
+    @test getUnitConversionForParameter("1-day", "day") == getUnitConversionForParameter("day", "day")
+
+    # n-unit on both sides
+    @test getUnitConversionForParameter("2-day", "6-hour") ≈ getUnitConversionForParameter("day", "hour") * 6 / 2
+
+    # malformed strings propagate as errors
+    @test_throws ErrorException getUnitConversionForParameter("day", "0-hour")
+    @test_throws ErrorException getUnitConversionForParameter("day", "abc-hour")
+
+    # unrecognized non-empty base units now error on both sides
+    @test_throws ErrorException getUnitConversionForParameter("day", "fortnight")
+    @test_throws ErrorException getUnitConversionForParameter("fortnight", "day")
+end

--- a/src/Setup/setupInfo.jl
+++ b/src/Setup/setupInfo.jl
@@ -223,7 +223,8 @@ function setDatesInfo(info::NamedTuple)
         end
         tmp_dates = set_namedtuple_field(tmp_dates, (time_prop, prop_val))
     end
-    timestep = getfield(Dates, Symbol(titlecase(info.settings.experiment.basics.time.temporal_resolution)))(1)
+    tr_n, tr_unit = parseTemporalResolution(info.settings.experiment.basics.time.temporal_resolution)
+    timestep = getfield(Dates, Symbol(titlecase(tr_unit)))(tr_n)
     time_range = DateTime(info.settings.experiment.basics.time.date_begin):timestep:DateTime(info.settings.experiment.basics.time.date_end)
     tmp_dates = set_namedtuple_field(tmp_dates, (:temporal_resolution, info.settings.experiment.basics.time.temporal_resolution))
     tmp_dates = set_namedtuple_field(tmp_dates, (:timestep, timestep))


### PR DESCRIPTION
## Summary

Handle timestep for model run for n - timestep, e.g., "6-hour", "2-day" etc.

## Automatic tests

Automatically, every PR runs a fast, ubuntu-only check on every push to aid the developer.
`TestSimulations.yml` (changes under `src/`) and `SindbadTEM-benchmark.yml`'s `test-model` job
(changes under `SindbadTEM/src/Processes/`, scoped to just the approach(es) that changed) also
auto-run when relevant -- everything else, including `/test-tem`'s `test-tem`/`analyse-tem` jobs
and `/compile-os`'s full OS matrix, is on-demand only (see below).

As the last step before merging, run additional tests/ checks **when the change are final** that run on-demand triggered by the following comments in the PR:

- `/check-pr` to run the full suite of tests and checks (recommended)

Or, if certain, run just what's relevant to the changes:

- `/build-docs`: docstring or new-function changes
- `/compile-os`: changes under `src/`, `SindbadTEM/src/`, or `Project.toml` dependencies
- `/test-simulation`: changes to the core simulation run path (forward/optimization) outside `src/`
- `/test-tem`: changes to approach behavior outside `SindbadTEM/src/Processes/`


The results post automatically back to the comment in this PR as comments.

***Note that these workflows can also be run any time on any branch through:***

```Actions tab -> pick a workflow -> Run workflow -> select this branch```

