### PR TITLE
generalize permute dim; and fix for no time data

### DIFF
--- a/src/DataLoaders/utilsDataLoaders.jl
+++ b/src/DataLoaders/utilsDataLoaders.jl
@@ -114,23 +114,34 @@ end
 
 """
     getDimPermutation(datDims, permDims)
+
 Returns the permutation indices required to rearrange dimensions from `datDims` to match `permDims`.
 
+If a target dimension is missing from the source data, such as time for a purely
+spatial variable, it is left out of the permutation since it does not exist in
+this array. If the source data has a dimension that is not part of the target
+list at all, such as soil_depth for a spatiovertical variable, that dimension is
+kept and placed before the matched target dims, in its original relative order.
+This guarantees the target dims always end up trailing, in the order given by
+`permDims`, no matter how many dimensions the source variable has or what
+physical order they are stored in. Downstream callers such as
+`OmniTools.view_at_trailing_indices` rely on this trailing order when indexing a
+per-pixel location out of the array.
+
 # Arguments
-- `datDims`: Array of current dimension names or indices
-- `permDims`: Array of target dimension names or indices in desired order
+- `datDims`: array of current dimension names
+- `permDims`: array of target dimension names in desired order
 
 # Returns
-- Array of indices representing the required permutation
+- array of indices representing the required permutation
 """
 function getDimPermutation(datDims, permDims)
+    matched_dims = [pd for pd ∈ permDims if pd in datDims]
+    extra_dims = [dd for dd ∈ datDims if !(dd in permDims)]
+    desired_order = vcat(extra_dims, matched_dims)
     new_dim = Int[]
-    for pd ∈ permDims
-        datIndex = length(permDims)
-        if pd in datDims
-            datIndex = findfirst(isequal(pd), datDims)
-        end
-        push!(new_dim, datIndex)
+    for dd ∈ desired_order
+        push!(new_dim, findfirst(isequal(dd), datDims))
     end
     return new_dim
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,38 @@ using PolyesterForwardDiff, FiniteDifferences, FiniteDiff
     @test isdefined(Sindbad, :addExtensionToSindbad)
 end
 
+@testset "DataLoaders utilsDataLoaders basics" begin
+    using Sindbad.DataLoaders: getDimPermutation
+
+    # fully present spatiotemporal case
+    @test getDimPermutation([:lon, :lat, :time], [:time, :lat, :lon]) == [3, 2, 1]
+
+    # spatiovertical case where the extra dim soil_depth is not in the target list
+    # and must lead rather than trail
+    @test getDimPermutation([:lon, :lat, :soil_depth], [:time, :lat, :lon]) == [3, 2, 1]
+
+    # same semantics with the extra dim in a different physical position in the source
+    # this is the case the old length permDims fallback got wrong
+    @test getDimPermutation([:soil_depth, :lon, :lat], [:time, :lat, :lon]) == [1, 3, 2]
+
+    # purely spatial case with no time dim at all like f_pft
+    # must not crash or go out of range
+    @test getDimPermutation([:lon, :lat], [:time, :lat, :lon]) == [2, 1]
+
+    # target dim list already matches source order exactly so this is a no-op
+    @test getDimPermutation([:time, :lat, :lon], [:time, :lat, :lon]) == [1, 2, 3]
+
+    # result is always a valid permutation of 1 through length of datDims
+    for (datDims, permDims) in (
+        ([:lon, :lat, :time], [:time, :lat, :lon]),
+        ([:lon, :lat, :soil_depth], [:time, :lat, :lon]),
+        ([:soil_depth, :lon, :lat], [:time, :lat, :lon]),
+        ([:lon, :lat], [:time, :lat, :lon]),
+    )
+        @test sort(getDimPermutation(datDims, permDims)) == collect(1:length(datDims))
+    end
+end
+
 @testset "SindbadTEM model run (via Sindbad)" begin
     # Reuse SindbadTEM's lightweight mock inputs to validate that core TEM process models
     # are runnable when users only `using Sindbad`.


### PR DESCRIPTION
## Summary

When forcing dims do not have time as the first axis, permute them to have it so. Was failing for data which had no time dimension. This fixes cases on different orders of dims in different data and sets them to permute_dims values of forcing.json

## Automatic tests

Automatically, every PR runs a fast, ubuntu-only check on every push to aid the developer.
`TestSimulations.yml` (changes under `src/`) and `SindbadTEM-benchmark.yml`'s `test-model` job
(changes under `SindbadTEM/src/Processes/`, scoped to just the approach(es) that changed) also
auto-run when relevant -- everything else, including `/test-tem`'s `test-tem`/`analyse-tem` jobs
and `/compile-os`'s full OS matrix, is on-demand only (see below).

As the last step before merging, run additional tests/ checks **when the change are final** that run on-demand triggered by the following comments in the PR:

- `/check-pr` to run the full suite of tests and checks (recommended)

Or, if certain, run just what's relevant to the changes:

- `/build-docs`: docstring or new-function changes
- `/compile-os`: changes under `src/`, `SindbadTEM/src/`, or `Project.toml` dependencies
- `/test-simulation`: changes to the core simulation run path (forward/optimization) outside `src/`
- `/test-tem`: changes to approach behavior outside `SindbadTEM/src/Processes/`


The results post automatically back to the comment in this PR as comments.

***Note that these workflows can also be run any time on any branch through:***

```Actions tab -> pick a workflow -> Run workflow -> select this branch```

