### PR TITLE
model timescale checkers during test

### DIFF
--- a/SindbadTEM/Project.toml
+++ b/SindbadTEM/Project.toml
@@ -5,7 +5,7 @@ authors = ["SINDBAD Contributors <sindbad@bgc-jena.mpg.de>"]
 description = "Core terrestrial ecosystem model types and utilities for the SINDBAD framework"
 readme = "README.md"
 repository = "https://github.com/LandEcosystems/Sindbad.jl.git"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/SindbadTEM/src/Processes.jl
+++ b/SindbadTEM/src/Processes.jl
@@ -63,6 +63,21 @@ module Processes
     @metadata bounds (-Inf, Inf) Tuple
     @metadata units "" String
     export describe, bounds, units
+
+    """
+    Day-equivalent multiplier for each temporal-resolution unit SINDBAD supports. This is
+    the single source of truth for legal `timescale`/`temporal_resolution` unit strings --
+    add a new unit by adding one entry here.
+    """
+    const TIMESCALE_DAY_MULTIPLIER = Dict(
+        "second" => 1 / (60 * 60 * 24),
+        "minute" => 1 / (60 * 24),
+        "hour"   => 1 / 24,
+        "day"    => 1.0,
+        "month"  => 30.0,
+        "year"   => 365.0,
+    )
+    export TIMESCALE_DAY_MULTIPLIER
     export getApproachDocString
     # define dispatch structs for catching process errors
 

--- a/SindbadTEM/src/Utils.jl
+++ b/SindbadTEM/src/Utils.jl
@@ -14,6 +14,7 @@ module Utils
     export getSindbadModels
     export getTypedModel
     export getUnitConversionForParameter
+    export isValidTimescale
     export parseTemporalResolution
     export modelParameter
     export modelParameters
@@ -439,6 +440,19 @@ function parseTemporalResolution(resolution)
 end
 
 """
+    isValidTimescale(timescale)
+
+Checks whether a parameter `timescale` string is either blank (not time-dependent) or
+one of the units in `SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER`, optionally
+prefixed with a positive integer count (e.g. "8-day"). Propagates any error
+`parseTemporalResolution` raises for a malformed `<n>-<unit>` prefix.
+"""
+function isValidTimescale(timescale)
+    _, unit = parseTemporalResolution(timescale)
+    return isempty(unit) || haskey(SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER, unit)
+end
+
+"""
     getUnitConversionForParameter(p_timescale, model_timestep)
 
 helper/wrapper function to get unit conversion factors for model parameters that are timescale dependent
@@ -457,56 +471,15 @@ function getUnitConversionForParameter(p_timescale, model_timestep)
         return isempty(p_unit) ? base_conversion : base_conversion * m_n / p_n
     end
 
-    conversion = 1
-    time_multiplier = 1
-    # time multiplier compared to daily time steps
-    if m_unit == "second"
-        time_multiplier = 1/(60* 60 * 24)
-    elseif m_unit == "minute"
-        time_multiplier = 1/(60 * 24)
-    elseif m_unit == "halfhour"
-        time_multiplier = 1/48
-    elseif m_unit == "hour"
-        time_multiplier = 1/24
-    elseif m_unit == "day"
-        time_multiplier = 1
-    elseif m_unit == "week"
-        time_multiplier = 7
-    elseif m_unit == "month"
-        time_multiplier = 30
-    elseif m_unit == "year"
-        time_multiplier = 365
-    elseif m_unit == "decade"
-        time_multiplier = 365 * 10
-    else
-        error("running model at $(model_timestep) is not supported")
-    end
+    haskey(SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER, m_unit) || error("running model at $(model_timestep) is not supported")
+    m_days = SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER[m_unit]
 
-    # modelling at other time steps
-    if p_unit == "second"
-        conversion = 60 * 60 * 24 * time_multiplier
-    elseif p_unit == "minute"
-        conversion = 60 * 24 * time_multiplier
-    elseif p_unit == "halfhour"
-        conversion = 48 * time_multiplier
-    elseif p_unit == "hour"
-        conversion = 24 * time_multiplier
-    elseif p_unit == "day"
-        conversion = 1 * time_multiplier
-    elseif p_unit == "week"
-        conversion = 1/7 * time_multiplier
-    elseif p_unit == "month"
-        conversion = 1/30 * time_multiplier
-    elseif p_unit == "year"
-        conversion = 1/365 * time_multiplier
-    elseif p_unit == "decade"
-        conversion = 1/(365 * 10) * time_multiplier
-    elseif isempty(p_unit)
-        conversion = 1
-    else
-        error("parameter timescale \"$(p_timescale)\" is not supported")
-    end
-    return conversion
+    isempty(p_unit) && return 1
+
+    haskey(SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER, p_unit) || error("parameter timescale \"$(p_timescale)\" is not supported")
+    p_days = SindbadTEM.Processes.TIMESCALE_DAY_MULTIPLIER[p_unit]
+
+    return m_days / p_days
 end
 
 

--- a/SindbadTEM/test/runtests.jl
+++ b/SindbadTEM/test/runtests.jl
@@ -19,6 +19,7 @@ include(joinpath("test_data", "helpers.jl"))
 
 include("testDataCoverage.jl")
 include("testUnitConversion.jl")
+include("testParameterTimescales.jl")
 # checkApproaches.jl (every approach's define/precompute/compute -- update is opt-in, off by
 # default -- run against the real process sequence) deliberately isn't included here: it's pure
 # Julia logic with no OS-specific behavior, so running it across Pkg.test's full 3-OS x

--- a/SindbadTEM/test/testParameterTimescales.jl
+++ b/SindbadTEM/test/testParameterTimescales.jl
@@ -1,0 +1,39 @@
+include(joinpath(@__DIR__, "..", "..", "tools", "benchmark", "TestSindbadTEM", "scanApproachVariables.jl"))
+
+@testset "isValidTimescale" begin
+    @test isValidTimescale("")
+    @test isValidTimescale("day")
+    @test isValidTimescale("second")
+    @test isValidTimescale("minute")
+    @test isValidTimescale("hour")
+    @test isValidTimescale("month")
+    @test isValidTimescale("year")
+    @test isValidTimescale("8-day")
+    @test isValidTimescale("6-hour")
+    @test isValidTimescale("1-year")
+
+    @test !isValidTimescale("week")
+    @test !isValidTimescale("decade")
+    @test !isValidTimescale("halfhour")
+    @test !isValidTimescale("fortnight")
+    @test !isValidTimescale("Day")
+    @test !isValidTimescale("days")
+
+    @test_throws ErrorException isValidTimescale("0-day")
+    @test_throws ErrorException isValidTimescale("abc-day")
+end
+
+@testset "Parameter timescales are within the allowed set" begin
+    bad = Tuple{Symbol,Symbol,String}[]  # (approach, field, timescale)
+    for T in leafSubtypes(LandEcosystem)
+        model = T()
+        for fn in fieldnames(T)
+            ts = SindbadTEM.Processes.timescale(model, fn)
+            isValidTimescale(ts) || push!(bad, (nameof(T), fn, ts))
+        end
+    end
+    if !isempty(bad)
+        @error "Approaches with an unsupported parameter timescale" bad
+    end
+    @test isempty(bad)
+end

--- a/docs/src/pages/settings/experiment.md
+++ b/docs/src/pages/settings/experiment.md
@@ -25,7 +25,7 @@ The `basics` section defines core experiment settings and metadata.
     "time": {
       "date_begin": "Start date of the experiment (YYYY-MM-DD)",
       "date_end": "End date of the experiment (YYYY-MM-DD)",
-      "temporal_resolution": "Model simulation time step (one of: 'second', 'minute', 'halfhour', 'hour', 'day', 'week', 'month', 'year', 'decade')"
+      "temporal_resolution": "Model simulation time step (one of: 'second', 'minute', 'hour', 'day', 'month', 'year', optionally prefixed with an integer count, e.g. '8-day', '6-hour')"
     }
 }
 ```


### PR DESCRIPTION
## Summary

The temporal resolution of simulation is compared with timescale of parameters for unit conversion. But, there were no checks on the validity of timescale dependence. This PR fixes that.

## Automatic tests

Automatically, every PR runs a fast, ubuntu-only check on every push to aid the developer.
`TestSimulations.yml` (changes under `src/`) and `SindbadTEM-benchmark.yml`'s `test-model` job
(changes under `SindbadTEM/src/Processes/`, scoped to just the approach(es) that changed) also
auto-run when relevant -- everything else, including `/test-tem`'s `test-tem`/`analyse-tem` jobs
and `/compile-os`'s full OS matrix, is on-demand only (see below).

As the last step before merging, run additional tests/ checks **when the change are final** that run on-demand triggered by the following comments in the PR:

- `/check-pr` to run the full suite of tests and checks (recommended)

Or, if certain, run just what's relevant to the changes:

- `/build-docs`: docstring or new-function changes
- `/compile-os`: changes under `src/`, `SindbadTEM/src/`, or `Project.toml` dependencies
- `/test-simulation`: changes to the core simulation run path (forward/optimization) outside `src/`
- `/test-tem`: changes to approach behavior outside `SindbadTEM/src/Processes/`


The results post automatically back to the comment in this PR as comments.

***Note that these workflows can also be run any time on any branch through:***

```Actions tab -> pick a workflow -> Run workflow -> select this branch```

